### PR TITLE
Add CertPinBypass mod

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory("Mods/WakingUpNpcs")
 add_subdirectory("Mods/NoPause")
 add_subdirectory("Mods/SkipIntro")
 add_subdirectory("Mods/CodeGen")
+add_subdirectory("Mods/CertPinBypass")
 
 # Tools.
 add_subdirectory("Tools/DevLoader")
@@ -27,4 +28,5 @@ add_dependencies(DevLoader
 	NoPause
 	SkipIntro
 	CodeGen
+	CertPinBypass
 )

--- a/Mods/CertPinBypass/CMakeLists.txt
+++ b/Mods/CertPinBypass/CMakeLists.txt
@@ -1,0 +1,26 @@
+﻿cmake_minimum_required(VERSION 3.12)
+
+file(GLOB_RECURSE SRC_FILES
+	CONFIGURE_DEPENDS
+	Src/*.cpp
+	Src/*.c
+	Src/*.hpp
+	Src/*.h
+)
+
+add_library(CertPinBypass SHARED
+	${SRC_FILES}
+)
+
+set_target_properties(CertPinBypass PROPERTIES
+	MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+	CXX_STANDARD 20
+)
+
+target_include_directories(CertPinBypass PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/Src
+)
+
+target_link_libraries(CertPinBypass PRIVATE
+	ZHMModSDK
+)

--- a/Mods/CertPinBypass/Src/CertPinBypass.cpp
+++ b/Mods/CertPinBypass/Src/CertPinBypass.cpp
@@ -1,0 +1,18 @@
+#include "CertPinBypass.h"
+
+#include "Hooks.h"
+#include "Logging.h"
+
+#include <Glacier/ZScene.h>
+
+void CertPinBypass::Init()
+{
+	Hooks::Check_SSL_Cert->AddDetour(this, &CertPinBypass::On_Check_SSL_Cert);
+}
+
+DECLARE_PLUGIN_DETOUR(CertPinBypass, bool, On_Check_SSL_Cert, void* unk1, void* unk2)
+{
+	return HookResult<bool>(HookAction::Return(), true);
+}
+
+DECLARE_ZHM_PLUGIN(CertPinBypass);

--- a/Mods/CertPinBypass/Src/CertPinBypass.h
+++ b/Mods/CertPinBypass/Src/CertPinBypass.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <random>
+#include <unordered_map>
+
+#include "IPluginInterface.h"
+
+class CertPinBypass : public IPluginInterface
+{
+public:
+	void Init() override;
+	
+private:
+	DEFINE_PLUGIN_DETOUR(CertPinBypass, bool, On_Check_SSL_Cert, void*, void*)
+};
+
+DEFINE_ZHM_PLUGIN(CertPinBypass)

--- a/ZHMModSDK/Include/Hooks.h
+++ b/ZHMModSDK/Include/Hooks.h
@@ -46,4 +46,5 @@ public:
 	static Hook<ZRenderDevice* (ZRenderDevice* th)>* ZRenderDevice_ZRenderDevice;
 	static Hook<HRESULT(IUnknown* pAdapter, D3D_FEATURE_LEVEL MinimumFeatureLevel, REFIID riid, void** ppDevice)>* D3D12CreateDevice;
 	static Hook<void(ZRenderSwapChain* th, void* a2, bool a3)>* ZRenderSwapChain_Resize;
+	static Hook<bool(void*, void*)>* Check_SSL_Cert;
 };

--- a/ZHMModSDK/Src/Hooks.cpp
+++ b/ZHMModSDK/Src/Hooks.cpp
@@ -108,3 +108,9 @@ PATTERN_HOOK(
 	"xxxxxx",
 	ZRenderSwapChain_Resize, void(ZRenderSwapChain* th, void* a2, bool a3)
 )
+
+PATTERN_HOOK(
+	"\x48\x89\x54\x24\x10\x55\x53\x57\x48\x8D\xAC\x24\x40\xFF\xFF\xFF",
+	"xxxxxxxxxxxxxxxx",
+	Check_SSL_Cert, bool(void*, void*)
+)


### PR DESCRIPTION
This adds 1 new method hook, and a simple mod that uses it to skip the certificate pinning.
The search pattern should work for all versions since the logic was changed (in November 2020 I believe?).