### PR TITLE
Gave ZString typecasts to std::string_view and std::string

### DIFF
--- a/ZHMModSDK/Include/Glacier/ZString.h
+++ b/ZHMModSDK/Include/Glacier/ZString.h
@@ -99,11 +99,6 @@ public:
 		return ToStringView();
 	}
 
-	operator std::string() const
-	{
-		return std::string(ToStringView());
-	}
-
 public:
 	static ZString CopyFrom(const ZString& p_Other)
 	{

--- a/ZHMModSDK/Include/Glacier/ZString.h
+++ b/ZHMModSDK/Include/Glacier/ZString.h
@@ -94,6 +94,16 @@ public:
 		return std::string_view(c_str(), size());
 	}
 
+	operator std::string_view() const
+	{
+		return ToStringView();
+	}
+
+	operator std::string() const
+	{
+		return std::string(ToStringView());
+	}
+
 public:
 	static ZString CopyFrom(const ZString& p_Other)
 	{


### PR DESCRIPTION
Not sure if this is needed, but I wrote it to make it easier when I needed to store a ZString as a std::string so that I could use functions from the string library