### PR TITLE
Fix RPC Pushes

### DIFF
--- a/Mods/DiscordRichPresence/Src/DiscordClient.cpp
+++ b/Mods/DiscordRichPresence/Src/DiscordClient.cpp
@@ -16,6 +16,7 @@ void DiscordClient::Update(const std::string& p_State, const std::string& p_Deta
 	if (m_DiscordInitResult != discord::Result::Ok)
 	{
 		// Don't attempt to update Discord if we couldn't connect before
+		Logger::Trace("Skipped Discord update due to non-ok init result: {}", m_DiscordInitResult);
 		return;
 	}
 
@@ -29,6 +30,11 @@ void DiscordClient::Update(const std::string& p_State, const std::string& p_Deta
 	{
 		Logger::Trace("Activity Manager push completed with result: {}", p_Result);
 	});
+}
+
+void DiscordClient::Callback()
+{
+	m_Core->RunCallbacks();
 }
 
 void DiscordClient::Teardown()

--- a/Mods/DiscordRichPresence/Src/DiscordClient.cpp
+++ b/Mods/DiscordRichPresence/Src/DiscordClient.cpp
@@ -20,7 +20,7 @@ void DiscordClient::Update(const std::string& p_State, const std::string& p_Deta
 		return;
 	}
 
-	discord::Activity activity;
+	discord::Activity activity {};
 	activity.SetType(discord::ActivityType::Playing);
 	activity.SetState(p_State.c_str());
 	activity.SetDetails(p_Details.c_str());

--- a/Mods/DiscordRichPresence/Src/DiscordClient.h
+++ b/Mods/DiscordRichPresence/Src/DiscordClient.h
@@ -8,6 +8,7 @@ public:
 	void Initialize();
 	void Update(const std::string& p_State, const std::string& p_Details, const std::string& p_ImageKey);
 	void Teardown();
+	void Callback();
 private:
 	discord::Core* m_Core;
 	discord::Result m_DiscordInitResult;

--- a/Mods/DiscordRichPresence/Src/DiscordRpc.cpp
+++ b/Mods/DiscordRichPresence/Src/DiscordRpc.cpp
@@ -121,7 +121,7 @@ void DiscordRpc::PopulateCodenameHints()
 		{ "Sheep 9", "Nightcall" },
 		{ "Golden Gecko", "On Top Of The World" },
 		{ "Flu", "Patient Zero" },
-		{ "Snow Crane", "Situs Inversus" },
+		{ "SnowCrane", "Situs Inversus" },
 		{ "Ebola", "The Author" },
 		{ "Llama", "The Farewell" },
 		{ "Polarbear Graduation", "The Final Test" },

--- a/Mods/DiscordRichPresence/Src/DiscordRpc.cpp
+++ b/Mods/DiscordRichPresence/Src/DiscordRpc.cpp
@@ -78,6 +78,11 @@ void DiscordRpc::PopulateGameModes()
 	Logger::Trace("Finished populating game modes");
 }
 
+void DiscordRpc::OnDraw3D(IRenderer* p_Renderer)
+{
+	m_DiscordClient.Callback();
+}
+
 void DiscordRpc::PopulateCodenameHints()
 {
 	m_CodenameHints = {

--- a/Mods/DiscordRichPresence/Src/DiscordRpc.cpp
+++ b/Mods/DiscordRichPresence/Src/DiscordRpc.cpp
@@ -14,7 +14,7 @@ DiscordRpc::~DiscordRpc()
 	m_DiscordClient.Teardown();
 
 	const ZMemberDelegate<DiscordRpc, void(const SGameUpdateEvent&)> s_Delegate(this, &DiscordRpc::OnFrameUpdate);
-	Globals::GameLoopManager->UnregisterFrameUpdate(s_Delegate, 99999, EUpdateMode::eUpdatePlayMode);
+	Globals::GameLoopManager->UnregisterFrameUpdate(s_Delegate, 99999, EUpdateMode::eUpdateAlways);
 }
 
 void DiscordRpc::PreInit()
@@ -29,7 +29,7 @@ void DiscordRpc::PreInit()
 void DiscordRpc::OnEngineInitialized()
 {
 	const ZMemberDelegate<DiscordRpc, void(const SGameUpdateEvent&)> s_Delegate(this, &DiscordRpc::OnFrameUpdate);
-	Globals::GameLoopManager->RegisterFrameUpdate(s_Delegate, 99999, EUpdateMode::eUpdatePlayMode);
+	Globals::GameLoopManager->RegisterFrameUpdate(s_Delegate, 99999, EUpdateMode::eUpdateAlways);
 }
 
 void DiscordRpc::PopulateScenes()

--- a/Mods/DiscordRichPresence/Src/DiscordRpc.h
+++ b/Mods/DiscordRichPresence/Src/DiscordRpc.h
@@ -11,6 +11,7 @@ class DiscordRpc : public IPluginInterface
 public:
 	~DiscordRpc() override;
 	void PreInit() override;
+	void OnDraw3D(IRenderer* p_Renderer) override;
 
 private:
 	void PopulateScenes();

--- a/Mods/DiscordRichPresence/Src/DiscordRpc.h
+++ b/Mods/DiscordRichPresence/Src/DiscordRpc.h
@@ -11,7 +11,8 @@ class DiscordRpc : public IPluginInterface
 public:
 	~DiscordRpc() override;
 	void PreInit() override;
-	void OnDraw3D(IRenderer* p_Renderer) override;
+	void OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent);
+	void OnEngineInitialized() override;
 
 private:
 	void PopulateScenes();


### PR DESCRIPTION
Apparently `{}` is needed after `discord::Activity activity` ... just shows how much I know about C++ 😅 

Also implemented execution of Discord callbacks via `OnDraw3D` calls, just to make things proper.