### PR TITLE
Change VCPKG_ROOT variable to fix github workflow

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,7 @@
         "DIRECTX_ARCH": "x64",
         "CMAKE_CXX_COMPILER": "cl.exe",
         "CMAKE_TOOLCHAIN_FILE": {
-          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+          "value": "$env{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake",
           "type": "FILEPATH"
         },
         "VCPKG_TARGET_TRIPLET": "x64-windows",


### PR DESCRIPTION
This fixes the github workflow in accordance with https://github.com/actions/runner-images/issues/6376 which was put into effect on the 31st of October