### PR TITLE
Make mods menu bar scrollable

### DIFF
--- a/ZHMModSDK/Src/ModSDK.cpp
+++ b/ZHMModSDK/Src/ModSDK.cpp
@@ -527,8 +527,29 @@ void ModSDK::ThreadedStartup() {
 void ModSDK::OnDrawMenu() {
 	m_ModLoader->LockRead();
 
+	auto cursorPosX = ImGui::GetCursorPosX();
+	auto width = ImGui::GetWindowWidth();
+	auto height = ImGui::GetWindowHeight();
+
+	ImGui::PushClipRect(ImVec2(cursorPosX, 0), ImVec2(width, height), true);
+	ImGui::BeginGroup();
+	ImGui::SetCursorPosX(cursorPosX - (float)(int)m_LoadedModsUIScrollOffset);
+
 	for (auto& s_Mod: m_ModLoader->GetLoadedMods())
 		s_Mod->OnDrawMenu();
+
+	ImGui::EndGroup();
+	ImGui::PopClipRect();
+
+	auto modMenusWidth = ImGui::GetCursorPosX();
+
+	if (ImGui::IsItemHovered())
+		m_LoadedModsUIScrollOffset += ImGui::GetIO().MouseWheel * -10.0f;
+
+	if (m_LoadedModsUIScrollOffset < 0)
+		m_LoadedModsUIScrollOffset = 0;
+	if (modMenusWidth < width)
+		m_LoadedModsUIScrollOffset -= width - modMenusWidth;
 
 	m_ModLoader->UnlockRead();
 }

--- a/ZHMModSDK/Src/ModSDK.h
+++ b/ZHMModSDK/Src/ModSDK.h
@@ -138,6 +138,7 @@ private:
     uint32_t m_SizeOfCode;
     uint32_t m_ImageSize;
 	std::string m_IgnoredVersion;
+	float m_LoadedModsUIScrollOffset = 0;
 
     std::shared_ptr<ModLoader> m_ModLoader {};
 


### PR DESCRIPTION
Fixes #100 

Allows hovering over the mods menu bar and using the scroll wheel to scroll it horizontally.