### PR TITLE
[Editor] Add EditorServer Enabled Checkbox

### DIFF
--- a/Mods/Editor/Src/Editor.cpp
+++ b/Mods/Editor/Src/Editor.cpp
@@ -98,6 +98,11 @@ void Editor::Init()
 
 void Editor::OnDrawMenu()
 {
+	bool s_ServerEnabled = m_Server.GetEnabled();
+	if (ImGui::Checkbox("EDITOR SERVER ENABLED", &s_ServerEnabled)) {
+		ToggleEditorServerEnabled();
+	}
+
     /*if (ImGui::Button(ICON_MD_VIDEO_SETTINGS "  EDITOR"))
     {
         const auto s_Scene = Globals::Hitman5Module->m_pEntitySceneContext->m_pScene;
@@ -154,6 +159,10 @@ void Editor::OnDrawMenu()
     }*/
 }
 
+
+void Editor::ToggleEditorServerEnabled() {
+	m_Server.SetEnabled(!m_Server.GetEnabled());
+}
 
 void Editor::CopyToClipboard(const std::string& p_String) const
 {

--- a/Mods/Editor/Src/Editor.h
+++ b/Mods/Editor/Src/Editor.h
@@ -80,6 +80,8 @@ private:
 
     static bool ImGuiCopyWidget(const std::string& p_Id);
 
+	void ToggleEditorServerEnabled();
+
 	// Properties
 	void UnsupportedProperty(const std::string& p_Id, ZEntityRef p_Entity, ZEntityProperty* p_Property, void* p_Data);
 

--- a/Mods/Editor/Src/EditorServer.h
+++ b/Mods/Editor/Src/EditorServer.h
@@ -37,6 +37,8 @@ public:
 	void OnSceneLoading(const std::string& p_Scene, const std::vector<std::string>& p_Bricks);
 	void OnSceneClearing(bool p_ForReload);
 	void OnEntityTreeRebuilt();
+	void SetEnabled(bool p_Enabled);
+	bool GetEnabled();
 
 private:
 	static void OnMessage(WebSocket* p_Socket, std::string_view p_Message) noexcept(false);
@@ -72,4 +74,5 @@ private:
 	uWS::Loop* m_Loop;
 	std::vector<SocketUserData*> m_SocketUserDatas;
 	std::jthread m_ServerThread;
+	static bool m_Enabled;
 };


### PR DESCRIPTION
There are times when working with GlacierKit and the Editor mod where you want to be able to modify an entity in GlacierKit without having the changes be reflected in Editor or vice versa.

This PR adds a checkbox toggle to the menu to allow disabling / enabling the EditorServer. When disabled, messages received by EditorServer will be ignored, and EditorServer will not send messages. The socket is kept open, so after reenabling, messages are sent and received again without the need for another handshake.

![image](https://github.com/OrfeasZ/ZHMModSDK/assets/5209876/89cb55cf-be62-4ff0-a783-5361170d557a)
![image](https://github.com/OrfeasZ/ZHMModSDK/assets/5209876/a5b3f680-d94e-4c47-9572-10bf1f1480f8)
![image](https://github.com/OrfeasZ/ZHMModSDK/assets/5209876/4fc848c3-6c37-4dc5-9c6f-d76f57bc988d)
![image](https://github.com/OrfeasZ/ZHMModSDK/assets/5209876/80c60e4b-f051-407f-8350-27d165587698)

Since this takes up some real estate on the menu bar, #111 would work well with this.