### PR TITLE
GetPluginSettingBool uses default value if the value is invalid, instead of false

### DIFF
--- a/ZHMModSDK/Src/ModSDK.cpp
+++ b/ZHMModSDK/Src/ModSDK.cpp
@@ -936,7 +936,13 @@ bool ModSDK::GetPluginSettingBool(IPluginInterface* p_Plugin, const ZString& p_S
 
 	const auto s_Value = s_Settings->GetSetting(p_Section.c_str(), p_Name.c_str(), p_DefaultValue ? "true" : "false");
 
-	return s_Value == "true" || s_Value == "1" || s_Value == "yes" || s_Value == "on" || s_Value == "y";
+	if (s_Value == "true" || s_Value == "1" || s_Value == "yes" || s_Value == "on" || s_Value == "y") {
+		return true;
+	} else if (s_Value == "false" || s_Value == "0" || s_Value == "no" || s_Value == "off" || s_Value == "n") {
+		return false;
+	} else {
+		return p_DefaultValue;
+	}
 }
 
 bool ModSDK::HasPluginSetting(IPluginInterface* p_Plugin, const ZString& p_Section, const ZString& p_Name) {


### PR DESCRIPTION
Tiny fix to make GetPluginSettingBool return what the doco says it does, IE if it's not a bool, return the default value (not false).
"* @return The value of the setting, or the default value if the setting does not exist or is not a boolean."