### PR TITLE
Fix editor style freecam

### DIFF
--- a/Mods/FreeCam/Src/FreeCam.cpp
+++ b/Mods/FreeCam/Src/FreeCam.cpp
@@ -342,7 +342,7 @@ void FreeCam::OnDrawUI(bool p_HasFocus) {
 				ToggleFreecam();
 			}
 
-			ImGui::BeginDisabled(!s_FreeCamActive);
+			ImGui::BeginDisabled(s_FreeCamActive);
 			ImGui::Checkbox("Use editor style freecam", &m_EditorStyleFreecam);
 			ImGui::EndDisabled();
 


### PR DESCRIPTION
Changes the editor style checkbox to be disabled while the freecam is active instead of the other way around. This fixes being able to enable it since it can only be enabled while the freecam itself is disabled otherwise it causes issues.