### PR TITLE
Draw scaleform detour crash fix

### DIFF
--- a/ZHMModSDK/Src/ModSDK.cpp
+++ b/ZHMModSDK/Src/ModSDK.cpp
@@ -1412,8 +1412,10 @@ DEFINE_DETOUR_WITH_CONTEXT(
     ZRenderDepthStencilView** dsv,
     uint32_t a5, bool bCaptureOnly
 ) {
-    if (*dsv && m_DirectXTKRenderer) {
-        m_DirectXTKRenderer->SetDsvIndex((*Globals::D3D12ObjectPools)->DepthStencilViews.IndexOf(*dsv) + 1);
+    if(dsv) {
+        if (*dsv && m_DirectXTKRenderer) {
+            m_DirectXTKRenderer->SetDsvIndex((*Globals::D3D12ObjectPools)->DepthStencilViews.IndexOf(*dsv) + 1);
+        }
     }
 
     return HookResult<void>(HookAction::Continue());

--- a/ZHMModSDK/Src/ModSDK.cpp
+++ b/ZHMModSDK/Src/ModSDK.cpp
@@ -1337,8 +1337,8 @@ DEFINE_DETOUR_WITH_CONTEXT(ModSDK, bool, Engine_Init, void* th, void* a2) {
 }
 
 using EOS_Bool = int32_t;
-constexpr auto EOS_TRUE = 1;
-constexpr auto EOS_FALSE = 0;
+#define EOS_TRUE 1
+#define EOS_FALSE 0
 
 struct EOS_Platform_ClientCredentials {
     const char* ClientId;
@@ -1361,8 +1361,8 @@ struct EOS_Platform_Options {
     uint32_t TickBudgetInMilliseconds;
 };
 
-constexpr auto EOS_PF_LOADING_IN_EDITOR = 0x00001;
-constexpr auto EOS_PF_DISABLE_OVERLAY = 0x00002;
+#define EOS_PF_LOADING_IN_EDITOR 0x00001
+#define EOS_PF_DISABLE_OVERLAY 0x00002
 
 DEFINE_DETOUR_WITH_CONTEXT(ModSDK, EOS_PlatformHandle*, EOS_Platform_Create, EOS_Platform_Options* Options) {
     // Disable overlay in debug mode since it conflicts with Nsight and the like.

--- a/ZHMModSDK/Src/ModSDK.cpp
+++ b/ZHMModSDK/Src/ModSDK.cpp
@@ -1336,7 +1336,7 @@ DEFINE_DETOUR_WITH_CONTEXT(ModSDK, bool, Engine_Init, void* th, void* a2) {
     return HookResult<bool>(HookAction::Return(), s_Result);
 }
 
-using EOS_Bool = int32_t;
+typedef int32_t EOS_Bool;
 #define EOS_TRUE 1
 #define EOS_FALSE 0
 

--- a/ZHMModSDK/Src/ModSDK.h
+++ b/ZHMModSDK/Src/ModSDK.h
@@ -53,8 +53,8 @@ public:
 
 private:
     void LoadConfiguration();
-    std::pair<uint32_t, std::string> RequestLatestVersion();
-    void ShowVersionNotice(const std::string& p_Version);
+    static std::pair<uint32_t, std::string> RequestLatestVersion();
+    static void ShowVersionNotice(const std::string& p_Version);
     void SkipVersionUpdate(const std::string& p_Version);
     void CheckForUpdates() const;
 

--- a/ZHMModSDK/Src/ModSDK.h
+++ b/ZHMModSDK/Src/ModSDK.h
@@ -45,7 +45,7 @@ public:
     ~ModSDK();
 
     bool Startup();
-    void ThreadedStartup();
+    void ThreadedStartup() const;
 
     uintptr_t GetModuleBase() const { return m_ModuleBase; }
     uint32_t GetSizeOfCode() const { return m_SizeOfCode; }
@@ -56,15 +56,15 @@ private:
     std::pair<uint32_t, std::string> RequestLatestVersion();
     void ShowVersionNotice(const std::string& p_Version);
     void SkipVersionUpdate(const std::string& p_Version);
-    void CheckForUpdates();
+    void CheckForUpdates() const;
 
 public:
-    void OnEngineInit();
     void OnModLoaded(const std::string& p_Name, IPluginInterface* p_Mod, bool p_LiveLoad);
     void OnModUnloaded(const std::string& p_Name);
-    void OnDrawUI(bool p_HasFocus);
-    void OnDraw3D();
-    void OnDrawMenu();
+    void OnEngineInit() const;
+    void OnDrawUI(bool p_HasFocus) const;
+    void OnDraw3D() const;
+    void OnDrawMenu() const;
 
 public:
     void SetSwapChain(Rendering::D3D12SwapChain* p_SwapChain);


### PR DESCRIPTION
It seems a crash caused by a nullptr occurs when calling DrawScale_form

Simple nullptr check added, and some simple refactoring/tidying up