### PR TITLE
[Editor] - Minor Improvements

### DIFF
--- a/Mods/DebugMod/Src/DebugMod.cpp
+++ b/Mods/DebugMod/Src/DebugMod.cpp
@@ -45,8 +45,6 @@ DebugMod::~DebugMod() {
         DisableTrackCam();
     }
 
-    m_raycastLogging = false;
-
     const ZMemberDelegate<DebugMod, void(const SGameUpdateEvent&)> s_Delegate(this, &DebugMod::OnFrameUpdate);
     Globals::GameLoopManager->UnregisterFrameUpdate(s_Delegate, 1, EUpdateMode::eUpdatePlayMode);
 }
@@ -170,22 +168,15 @@ void DebugMod::OnMouseDown(SVector2 p_Pos, bool p_FirstClick) {
     };
 
     ZRayQueryOutput s_RayOutput {};
-    if(m_raycastLogging) {
-        Logger::Debug("RayCasting from {} to {}.", s_From, s_To);
-    }
+    Logger::Debug("RayCasting from {} to {}.", s_From, s_To);
 
     if (!(*Globals::CollisionManager)->RayCastClosestHit(s_RayInput, &s_RayOutput)) {
-        if(m_raycastLogging) {
-            Logger::Error("Raycast failed.");
-        }
-
+        Logger::Error("Raycast failed.");
         m_SelectedEntity = nullptr;
         return;
     }
 
-    if(m_raycastLogging) {
-        Logger::Debug("Raycast result: {} {}", fmt::ptr(&s_RayOutput), s_RayOutput.m_vPosition);
-    }
+    Logger::Debug("Raycast result: {} {}", fmt::ptr(&s_RayOutput), s_RayOutput.m_vPosition);
 
     m_From = s_From;
     m_To = s_To;
@@ -239,7 +230,6 @@ void DebugMod::DrawOptions(const bool p_HasFocus) {
     ImGui::PushFont(SDK()->GetImGuiRegularFont());
 
     if (s_Showing) {
-        ImGui::Checkbox("Raycast logging", &m_raycastLogging);
         ImGui::Checkbox("Render NPC position boxes", &m_RenderNpcBoxes);
         ImGui::Checkbox("Render NPC names", &m_RenderNpcNames);
         ImGui::Checkbox("Render NPC repository IDs", &m_RenderNpcRepoIds);

--- a/Mods/DebugMod/Src/DebugMod.cpp
+++ b/Mods/DebugMod/Src/DebugMod.cpp
@@ -45,6 +45,8 @@ DebugMod::~DebugMod() {
         DisableTrackCam();
     }
 
+    m_raycastLogging = false;
+
     const ZMemberDelegate<DebugMod, void(const SGameUpdateEvent&)> s_Delegate(this, &DebugMod::OnFrameUpdate);
     Globals::GameLoopManager->UnregisterFrameUpdate(s_Delegate, 1, EUpdateMode::eUpdatePlayMode);
 }
@@ -168,16 +170,22 @@ void DebugMod::OnMouseDown(SVector2 p_Pos, bool p_FirstClick) {
     };
 
     ZRayQueryOutput s_RayOutput {};
-
-    Logger::Debug("RayCasting from {} to {}.", s_From, s_To);
+    if(m_raycastLogging) {
+        Logger::Debug("RayCasting from {} to {}.", s_From, s_To);
+    }
 
     if (!(*Globals::CollisionManager)->RayCastClosestHit(s_RayInput, &s_RayOutput)) {
-        Logger::Error("Raycast failed.");
+        if(m_raycastLogging) {
+            Logger::Error("Raycast failed.");
+        }
+
         m_SelectedEntity = nullptr;
         return;
     }
 
-    Logger::Debug("Raycast result: {} {}", fmt::ptr(&s_RayOutput), s_RayOutput.m_vPosition);
+    if(m_raycastLogging) {
+        Logger::Debug("Raycast result: {} {}", fmt::ptr(&s_RayOutput), s_RayOutput.m_vPosition);
+    }
 
     m_From = s_From;
     m_To = s_To;
@@ -231,6 +239,7 @@ void DebugMod::DrawOptions(const bool p_HasFocus) {
     ImGui::PushFont(SDK()->GetImGuiRegularFont());
 
     if (s_Showing) {
+        ImGui::Checkbox("Raycast logging", &m_raycastLogging);
         ImGui::Checkbox("Render NPC position boxes", &m_RenderNpcBoxes);
         ImGui::Checkbox("Render NPC names", &m_RenderNpcNames);
         ImGui::Checkbox("Render NPC repository IDs", &m_RenderNpcRepoIds);

--- a/Mods/DebugMod/Src/DebugMod.h
+++ b/Mods/DebugMod/Src/DebugMod.h
@@ -113,8 +113,6 @@ private:
     bool m_RenderRaycast = false;
     bool m_UseSnap = false;
 
-    bool m_raycastLogging; // Mainly used for the raycasting logs
-
     float m_SnapValue[3] = {1.0f, 1.0f, 1.0f};
 
     float4 m_From;

--- a/Mods/DebugMod/Src/DebugMod.h
+++ b/Mods/DebugMod/Src/DebugMod.h
@@ -113,6 +113,8 @@ private:
     bool m_RenderRaycast = false;
     bool m_UseSnap = false;
 
+    bool m_raycastLogging; // Mainly used for the raycasting logs
+
     float m_SnapValue[3] = {1.0f, 1.0f, 1.0f};
 
     float4 m_From;

--- a/Mods/Editor/Src/Components/EntityProperties.cpp
+++ b/Mods/Editor/Src/Components/EntityProperties.cpp
@@ -365,6 +365,10 @@ void Editor::DrawEntityProperties() {
                     ImGui::Text("%s", s_PropertyInfo->m_pName);
                 }
 
+                if(ImGui::IsItemHovered())
+                {
+                    ImGui::SetTooltip("%s", s_PropertyInfo->m_pType->typeInfo()->m_pTypeName);
+                }
                 ImGui::PopFont();
                 ImGui::SameLine();
 

--- a/Mods/Editor/Src/Components/EntityProperties.cpp
+++ b/Mods/Editor/Src/Components/EntityProperties.cpp
@@ -436,6 +436,10 @@ void Editor::DrawEntityProperties() {
                 else if (s_PropertyInfo->m_pType->typeInfo()->isResource()) {
                     ResourceProperty(s_InputId, s_SelectedEntity, s_Property, s_Data);
                 }
+                else if(s_TypeName.starts_with("TEntityRef<"))
+                {
+                    TEntityRefProperty(s_InputId, s_SelectedEntity, s_Property, s_Data);
+                }
                 else {
                     UnsupportedProperty(s_InputId, s_SelectedEntity, s_Property, s_Data);
                 }

--- a/Mods/Editor/Src/Components/EntityTree.cpp
+++ b/Mods/Editor/Src/Components/EntityTree.cpp
@@ -62,6 +62,7 @@ void Editor::UpdateEntities() {
     // Create the root scene node.
     auto s_SceneNode = std::make_shared<EntityTreeNode>(
         "Scene Root",
+        s_SceneEnt->GetType()->m_pInterfaces->operator[](0).m_pTypeId->typeInfo()->m_pTypeName,
         s_SceneEnt->GetType()->m_nEntityId,
         s_SceneFactory->m_ridResource,
         s_SceneEnt
@@ -108,15 +109,15 @@ void Editor::UpdateEntities() {
             const auto s_EntityTypeName = s_SubEntity->GetType()->m_pInterfaces->operator[](0).m_pTypeId->typeInfo()->
                                                        m_pTypeName;
             const auto s_EntityHumanName = fmt::format(
-                "{}::{} ({:08x})",
+                "{} ({:08x})",
                 s_EntityName,
-                s_EntityTypeName,
                 s_SubEntityId
             );
 
             // Add the node to the map.
             const auto s_SubEntityNode = std::make_shared<EntityTreeNode>(
                 s_EntityHumanName,
+                s_EntityTypeName,
                 s_SubEntityId,
                 s_CurrentFactory->m_ridResource,
                 s_SubEntity
@@ -183,6 +184,7 @@ void Editor::RenderEntity(std::shared_ptr<EntityTreeNode> p_Node) {
     if (!p_Node) return;
 
     const auto s_Entity = p_Node->Entity;
+    const auto s_EntityType = p_Node->EntityType;
     const auto s_EntityName = p_Node->Name;
     const auto s_IsSelected = s_Entity == m_SelectedEntity;
 
@@ -209,6 +211,11 @@ void Editor::RenderEntity(std::shared_ptr<EntityTreeNode> p_Node) {
         s_EntityName.c_str(),
         s_Flags
     );
+
+    if(ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("%s", s_EntityType.c_str());
+    }
 
     if (ImGui::IsItemClicked()) {
         OnSelectEntity(s_Entity, std::nullopt);

--- a/Mods/Editor/Src/Components/EntityTree.cpp
+++ b/Mods/Editor/Src/Components/EntityTree.cpp
@@ -403,7 +403,7 @@ void Editor::DrawEntityTree() {
     }
 }
 
-void Editor::OnSelectEntity(ZEntityRef p_Entity, const std::optional<std::string>& p_ClientId) {
+void Editor::OnSelectEntity(ZEntityRef p_Entity, const std::optional<std::string> p_ClientId) {
     const bool s_DifferentEntity = m_SelectedEntity.m_pEntity != p_Entity.m_pEntity;
 
     m_ShouldScrollToEntity = p_Entity.GetEntity() != nullptr;

--- a/Mods/Editor/Src/Components/EntityTree.cpp
+++ b/Mods/Editor/Src/Components/EntityTree.cpp
@@ -300,6 +300,8 @@ void Editor::DrawEntityTree() {
     ImGui::SetNextWindowSize({700, ImGui::GetIO().DisplaySize.y - 110}, ImGuiCond_FirstUseEver);
     ImGui::Begin(ICON_MD_CATEGORY " Entities", nullptr, ImGuiWindowFlags_HorizontalScrollbar);
 
+    ImGui::Checkbox("Raycast logging", &m_raycastLogging);
+
     const auto s_SceneCtx = Globals::Hitman5Module->m_pEntitySceneContext;
 
     if (s_SceneCtx && s_SceneCtx->m_pScene && s_SceneCtx->m_aLoadedBricks.size() > 0) {
@@ -338,7 +340,8 @@ void Editor::DrawEntityTree() {
                 const auto s_BpFactory = reinterpret_cast<ZTemplateEntityBlueprintFactory*>(s_Brick.entityRef.
                     GetBlueprintFactory());
 
-                if (SearchForEntityByType(s_BpFactory, s_Brick.entityRef, s_EntityTypeSearchInput)) {
+                if (SearchForEntityByType(s_BpFactory, s_Brick.entityRef, s_EntityTypeSearchInput)) 
+                {
                     Logger::Debug("Found entity in brick {} (idx = {}).", s_Brick.runtimeResourceID, i);
                     m_SelectedBrickIndex = i;
                     break;
@@ -400,14 +403,18 @@ void Editor::DrawEntityTree() {
     }
 }
 
-void Editor::OnSelectEntity(ZEntityRef p_Entity, std::optional<std::string> p_ClientId) {
-    const bool s_DifferentEntity = m_SelectedEntity != p_Entity;
+void Editor::OnSelectEntity(ZEntityRef p_Entity, const std::optional<std::string>& p_ClientId) {
+    const bool s_DifferentEntity = m_SelectedEntity.m_pEntity != p_Entity.m_pEntity;
 
-    m_SelectedEntity = p_Entity;
     m_ShouldScrollToEntity = p_Entity.GetEntity() != nullptr;
 
     if (s_DifferentEntity) {
         m_Server.OnEntitySelected(p_Entity, std::move(p_ClientId));
+        m_SelectedEntity = p_Entity;
+    }
+    else
+    {
+        m_SelectedEntity = nullptr; //Unselect it
     }
 
     if (!m_SelectionForFreeCameraEditorStyleEntity) {

--- a/Mods/Editor/Src/Editor.cpp
+++ b/Mods/Editor/Src/Editor.cpp
@@ -559,7 +559,7 @@ void Editor::OnMouseDown(SVector2 p_Pos, bool p_FirstClick) {
             );
 
             const auto s_SceneCtx = Globals::Hitman5Module->m_pEntitySceneContext;
-            s_SelectedEntity = s_RayOutput.m_BlockingEntity;
+            ZEntityRef s_SelectedEntity = s_RayOutput.m_BlockingEntity;
 
             for (int i = 0; i < s_SceneCtx->m_aLoadedBricks.size(); ++i) {
                 const auto& s_Brick = s_SceneCtx->m_aLoadedBricks[i];

--- a/Mods/Editor/Src/Editor.cpp
+++ b/Mods/Editor/Src/Editor.cpp
@@ -70,6 +70,8 @@ Editor::Editor() {
     m_QneAddress.sin_family = AF_INET;
     m_QneAddress.sin_port = htons(49494);
     m_QneAddress.sin_addr.S_un.S_addr = inet_addr("127.0.0.1");
+
+    m_raycastLogging = false;
 }
 
 Editor::~Editor() {
@@ -528,14 +530,20 @@ void Editor::OnMouseDown(SVector2 p_Pos, bool p_FirstClick) {
 
     ZRayQueryOutput s_RayOutput {};
 
-    Logger::Debug("RayCasting from {} to {}.", s_From, s_To);
+    if(m_raycastLogging) {
+        Logger::Debug("RayCasting from {} to {}.", s_From, s_To);
+    }
 
     if (!(*Globals::CollisionManager)->RayCastClosestHit(s_RayInput, &s_RayOutput)) {
-        Logger::Error("Raycast failed.");
+        if(m_raycastLogging){
+            Logger::Error("Raycast failed.");
+        }
         return;
     }
 
-    Logger::Debug("Raycast result: {} {}", fmt::ptr(&s_RayOutput), s_RayOutput.m_vPosition);
+    if(m_raycastLogging) {
+        Logger::Debug("Raycast result: {} {}", fmt::ptr(&s_RayOutput), s_RayOutput.m_vPosition);
+    }
 
     m_From = s_From;
     m_To = s_To;
@@ -550,8 +558,8 @@ void Editor::OnMouseDown(SVector2 p_Pos, bool p_FirstClick) {
                 s_RayOutput.m_BlockingEntity->GetType()->m_nEntityId
             );
 
-            const auto s_SelectedEntity = s_RayOutput.m_BlockingEntity;
             const auto s_SceneCtx = Globals::Hitman5Module->m_pEntitySceneContext;
+            s_SelectedEntity = s_RayOutput.m_BlockingEntity;
 
             for (int i = 0; i < s_SceneCtx->m_aLoadedBricks.size(); ++i) {
                 const auto& s_Brick = s_SceneCtx->m_aLoadedBricks[i];

--- a/Mods/Editor/Src/Editor.h
+++ b/Mods/Editor/Src/Editor.h
@@ -145,10 +145,12 @@ private:
 private:
     ZEntityRef m_Camera;
     ZEntityRef m_CameraRT;
+    bool m_raycastLogging; // Mainly used for the raycasting logs
 
     bool m_CameraActive = false;
     ZEntityRef m_OriginalCam;
 
+    ZEntityRef s_SelectedEntity;
     ZSelectionForFreeCameraEditorStyleEntity* m_SelectionForFreeCameraEditorStyleEntity = nullptr;
 
     bool m_HoldingMouse = false;

--- a/Mods/Editor/Src/Editor.h
+++ b/Mods/Editor/Src/Editor.h
@@ -151,7 +151,6 @@ private:
     bool m_CameraActive = false;
     ZEntityRef m_OriginalCam;
 
-    ZEntityRef s_SelectedEntity;
     ZSelectionForFreeCameraEditorStyleEntity* m_SelectionForFreeCameraEditorStyleEntity = nullptr;
 
     bool m_HoldingMouse = false;

--- a/Mods/Editor/Src/Editor.h
+++ b/Mods/Editor/Src/Editor.h
@@ -100,6 +100,7 @@ private:
 
     // Properties
     void UnsupportedProperty(const std::string& p_Id, ZEntityRef p_Entity, ZEntityProperty* p_Property, void* p_Data);
+    void TEntityRefProperty(const std::string& p_Id, ZEntityRef p_Entity, ZEntityProperty* p_Property, void* p_Data);
 
     // Primitive properties.
     void StringProperty(const std::string& p_Id, ZEntityRef p_Entity, ZEntityProperty* p_Property, void* p_Data);

--- a/Mods/Editor/Src/EntityTreeNode.h
+++ b/Mods/Editor/Src/EntityTreeNode.h
@@ -7,11 +7,12 @@
 
 struct EntityTreeNode {
     std::string Name;
+    std::string EntityType;
     uint64_t EntityId;
     ZRuntimeResourceID TBLU;
     ZEntityRef Entity;
     std::multimap<std::string, std::shared_ptr<EntityTreeNode>> Children;
 
-    EntityTreeNode(const std::string& p_Name, uint64_t p_EntityId, ZRuntimeResourceID p_TBLU, ZEntityRef p_Ref)
-        : Name(p_Name), EntityId(p_EntityId), TBLU(p_TBLU), Entity(p_Ref) {}
+    EntityTreeNode(const std::string& p_Name, const std::string& p_type, uint64_t p_EntityId, ZRuntimeResourceID p_TBLU, ZEntityRef p_Ref)
+        : Name(p_Name), EntityType(p_type), EntityId(p_EntityId), TBLU(p_TBLU), Entity(p_Ref) {}
 };

--- a/Mods/Editor/Src/Properties/Common.cpp
+++ b/Mods/Editor/Src/Properties/Common.cpp
@@ -25,5 +25,7 @@ void Editor::UnsupportedProperty(
 ) {
     const auto s_PropertyInfo = p_Property->m_pType->getPropertyInfo();
     const std::string s_TypeName = s_PropertyInfo->m_pType->typeInfo()->m_pTypeName;
-    ImGui::Text(" %s (Unsupported)", s_TypeName.c_str());
+
+    constexpr auto textColor = ImVec4(1.f, 1.f, 1.f, 0.5f);
+    ImGui::TextColored(textColor, "(Unsupported)", s_TypeName.c_str());
 }

--- a/Mods/Editor/Src/Properties/Common.cpp
+++ b/Mods/Editor/Src/Properties/Common.cpp
@@ -29,3 +29,35 @@ void Editor::UnsupportedProperty(
     constexpr auto textColor = ImVec4(1.f, 1.f, 1.f, 0.5f);
     ImGui::TextColored(textColor, "(Unsupported)", s_TypeName.c_str());
 }
+
+void Editor::TEntityRefProperty(const std::string& p_Id, ZEntityRef p_Entity, ZEntityProperty* p_Property, void* p_Data)
+{
+    if(auto EntityRef = reinterpret_cast<TEntityRef<void*>*>(p_Data)) {
+        ImVec4 linkColor = ImVec4(0.2f, 0.6f, 1.0f, 1.0f); // Light blue, like a link
+
+        ImGui::PushStyleColor(ImGuiCol_Text, linkColor);
+            ImGui::Text("%s", "link");
+        ImGui::PopStyleColor();
+
+        if (ImGui::IsItemHovered()) {
+            // Underline on hover
+            ImVec2 min = ImGui::GetItemRectMin();
+            ImVec2 max = ImGui::GetItemRectMax();
+            ImGui::GetWindowDrawList()->AddLine(
+                ImVec2(min.x, max.y),
+                ImVec2(max.x, max.y),
+                ImGui::GetColorU32(linkColor)
+            );
+        }
+
+        if(ImGui::IsItemClicked())
+        {
+            OnSelectEntity(EntityRef->m_ref, std::nullopt);
+        }
+    }
+    else
+    {
+        constexpr auto textColor = ImVec4(1.f, 1.f, 1.f, 0.5f);
+        ImGui::TextColored(textColor, "(%s)", "null");
+    }
+}


### PR DESCRIPTION
* Display "Unsupported" rather than the datatype
* All TEntityRef are now clickable links to relevant entity 
* Datatype can be viewed via hovertext for each property
* User can toggle Raycast logging (default: off/false)
* Deselect already selected entities if selected again

Note: The hovertext below in the image (mouse not being shown)
![image](https://github.com/user-attachments/assets/155a90eb-68c0-4f03-b2f9-5378ea89b6dd)








Edit - I have also done the same with the EntityTree. I feel it makes things easier to read/glance at:

Do you think the ResourceID should be faded/given a different colour?

![{7B99F4EB-2598-405E-8DE6-310C91ADD5C8}](https://github.com/user-attachments/assets/08f2ff9a-a44b-4d53-bc03-2df93073b72f)



Links to related entity!
![image](https://github.com/user-attachments/assets/0b1c8d9b-c78c-4a29-a129-f03cec05a806)

