### PR TITLE
sanity check ActorManager and clear pointers on scene transition

### DIFF
--- a/Mods/DebugMod/Src/DebugMod.cpp
+++ b/Mods/DebugMod/Src/DebugMod.cpp
@@ -1226,6 +1226,10 @@ DEFINE_PLUGIN_DETOUR(DebugMod, void, OnClearScene, ZEntitySceneContext* th, bool
 
     m_GlobalOutfitKit = nullptr;
 
+    m_NPCsMenuActive = false;
+    s_CurrentlySelectedActor = nullptr;
+    m_SelectedEntity = nullptr;
+
     return HookResult<void>(HookAction::Continue());
 }
 

--- a/Mods/DebugMod/Src/UI/NPCsBox.cpp
+++ b/Mods/DebugMod/Src/UI/NPCsBox.cpp
@@ -23,6 +23,10 @@ void DebugMod::DrawNPCsBox(const bool p_HasFocus) {
     ImGui::PushFont(SDK()->GetImGuiRegularFont());
 
     if (s_Showing && p_HasFocus) {
+        if (!Globals::ActorManager) {
+            return;
+        }
+
         ZContentKitManager* s_ContentKitManager = Globals::ContentKitManager;
         ZEntityRef ref;
 


### PR DESCRIPTION
this PR checks for `Globals::ActorManager` before calling `DebugMenu::DrawNPCsBox`. when opening the NPC menu in one Elusive Target Arcade level and going to the next, `DebugMenu::DrawNPCsBox` goes through its loop but `Globals::ActorManager`. it also sets `s_CurrentlySelectedActor` and `m_SelectedEntity` to a null pointer which should fix the other part of this problem if you already have an NPC selected