### PR TITLE
Fix GetProperty crash on entities with no properties pointer

### DIFF
--- a/ZHMModSDK/Include/Glacier/ZEntity.h
+++ b/ZHMModSDK/Include/Glacier/ZEntity.h
@@ -116,6 +116,10 @@ public:
 class ZEntityType {
 public:
     ZEntityProperty* FindProperty(uint32_t p_PropertyId) const {
+        if (!m_pProperties01) {
+            return nullptr;
+        }
+
         auto s_Property = std::find_if(
             m_pProperties01->begin(),
             m_pProperties01->end(),

--- a/ZHMModSDK/Include/Glacier/ZEntity.h
+++ b/ZHMModSDK/Include/Glacier/ZEntity.h
@@ -364,7 +364,7 @@ public:
 
         const auto s_Type = s_Entity->GetType();
 
-        if (!s_Type)
+        if (!s_Type || !s_Type->m_pProperties01)
             return s_PropertyVal;
 
         for (uint32_t i = 0; i < s_Type->m_pProperties01->size(); ++i) {


### PR DESCRIPTION
Adds pointer checks to prevent crashes when using GetProperty and a related method on entities with null m_pProperties01 value.

<img width="1402" height="876" alt="image" src="https://github.com/user-attachments/assets/c432e9cb-6684-442e-ae6c-7688ed53fcce" />
