### PR TITLE
[Editor] Add Editor menu

### DIFF
--- a/Mods/Editor/Src/Editor.cpp
+++ b/Mods/Editor/Src/Editor.cpp
@@ -101,12 +101,12 @@ void Editor::Init() {
     m_UseScaleSnap = GetSettingBool("general", "scale_snap", true);
     m_ScaleSnapValue = GetSettingDouble("general", "scale_snap_value", 1.0);
     m_UseQneTransforms = GetSettingBool("general", "qne_transforms", false);
+    m_EditorWindowsVisible = GetSettingBool("general", "editor_windows_visible", true);
 }
 
 void Editor::OnDrawMenu() {
-    bool s_ServerEnabled = m_Server.GetEnabled();
-    if (ImGui::Checkbox("EDITOR SERVER", &s_ServerEnabled)) {
-        ToggleEditorServerEnabled();
+    if (ImGui::Button(ICON_MD_VIDEO_SETTINGS "  EDITOR")) {
+        m_MenuVisible = !m_MenuVisible;
     }
 
     /*if (ImGui::Button(ICON_MD_VIDEO_SETTINGS "  EDITOR"))
@@ -465,10 +465,35 @@ std::string BehaviorToString(ECompiledBehaviorType p_Type) {
 void Editor::OnDrawUI(bool p_HasFocus) {
     auto s_ImgGuiIO = ImGui::GetIO();
 
-    DrawEntityTree();
-    DrawEntityProperties();
-    DrawEntityManipulator(p_HasFocus);
-    //DrawPinTracer();
+    if (m_MenuVisible) {
+        const auto s_Center = ImGui::GetMainViewport()->GetCenter();
+        ImGui::SetNextWindowPos(s_Center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+        ImGui::PushFont(SDK()->GetImGuiBlackFont());
+        const auto s_MenuExpanded = ImGui::Begin(ICON_MD_VIDEO_SETTINGS "  Editor", &m_MenuVisible);
+        ImGui::PushFont(SDK()->GetImGuiRegularFont());
+
+        if (s_MenuExpanded) {
+            if (ImGui::Checkbox(ICON_MD_VIDEO_SETTINGS "  SHOW EDITOR WINDOWS", &m_EditorWindowsVisible)) {
+                SetSettingBool("general", "editor_windows_visible", m_EditorWindowsVisible);
+            }
+            bool s_ServerEnabled = m_Server.GetEnabled();
+            if (ImGui::Checkbox(ICON_MD_TERMINAL "  ENABLE EDITOR SERVER", &s_ServerEnabled)) {
+                ToggleEditorServerEnabled();
+            }
+        }
+
+        ImGui::PopFont();
+        ImGui::End();
+        ImGui::PopFont();
+    }
+
+    if (m_EditorWindowsVisible) {
+        DrawEntityTree();
+        DrawEntityProperties();
+        DrawEntityManipulator(p_HasFocus);
+        //DrawPinTracer();
+    }
 
     if (m_CameraRT && m_Camera) {
         ImGui::Begin("RT Texture");

--- a/Mods/Editor/Src/Editor.h
+++ b/Mods/Editor/Src/Editor.h
@@ -192,6 +192,9 @@ private:
     double m_AngleSnapValue = 90.0;
     double m_ScaleSnapValue = 1.0;
 
+    bool m_MenuVisible = false;
+    bool m_EditorWindowsVisible = true;
+
     float4 m_From;
     float4 m_To;
     float4 m_Hit;


### PR DESCRIPTION
This PR replaces the Editor Server checkbox on the menu bar with a button to open a popup menu with these options for the Editor mod:

1. Show / Hide the Editor windows
2. Enable / Disable the Editor server

<img width="1006" height="62" alt="image" src="https://github.com/user-attachments/assets/abde665d-2ee8-4557-8bab-92ffb79b8b53" />
<img width="445" height="203" alt="image" src="https://github.com/user-attachments/assets/dc6f1137-cf19-4711-a497-eddfc7d6f69a" />


https://github.com/user-attachments/assets/03a2113b-f745-41be-ace9-9b32aaf9aaa4

