### PR TITLE
Fix position box error popup

### DIFF
--- a/Mods/DebugMod/Src/UI/PositionBox.cpp
+++ b/Mods/DebugMod/Src/UI/PositionBox.cpp
@@ -192,9 +192,8 @@ void DebugMod::DrawPositionBox(bool p_HasFocus) {
                 );
             }
         }
-
-        ImGui::PopFont();
-        ImGui::End();
-        ImGui::PopFont();
     }
+    ImGui::PopFont();
+    ImGui::End();
+    ImGui::PopFont();
 }


### PR DESCRIPTION
## Description
This PR fixes the nesting for these imgui commands to avoid this error popup.

## After
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/f69e1d90-98e1-489a-835d-3d4d5a30d660" />

## Before
<img width="977" height="494" alt="image" src="https://github.com/user-attachments/assets/56a7e730-7e7c-477f-91fd-41a14eba0929" />
