### PR TITLE
Fix s_DisableNavmeshExportPropertyName check

### DIFF
--- a/Mods/Editor/Src/EditorServer.cpp
+++ b/Mods/Editor/Src/EditorServer.cpp
@@ -926,7 +926,7 @@ bool EditorServer::IsExcludedFromNavMeshExport(const ZEntityRef& p_Entity) {
                         }
                     }
                     else if (s_PropertyNameView == s_DisableNavmeshExportPropertyName) {
-                        if (!IsPropertyValueTrue(s_Property, p_Entity)) {
+                        if (IsPropertyValueTrue(s_Property, p_Entity)) {
                             return true;
                         }
                     }
@@ -939,7 +939,7 @@ bool EditorServer::IsExcludedFromNavMeshExport(const ZEntityRef& p_Entity) {
                     }
                 }
                 else if (s_PropertyInfo->m_pName == s_DisableNavmeshExportPropertyName) {
-                    if (!IsPropertyValueTrue(s_Property, p_Entity)) {
+                    if (IsPropertyValueTrue(s_Property, p_Entity)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
This PR fixes a logical error in the `IsExcludedFromNavMeshExport` function.

It changes it to return `true` when `m_bDisableNavmeshExport` is `true` rather than incorrectly returning false.