### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/External/RakNet/DependentExtensions/miniupnpc-1.6.20120410/miniwget.c
+++ b/External/RakNet/DependentExtensions/miniupnpc-1.6.20120410/miniwget.c
@@ -157,7 +157,7 @@ getHTTPResponse(int s, int * size)
 							chunked = 1;
 						}
 					}
-					while(header_buf[i]=='\r' || header_buf[i] == '\n')
+					while((i < (int)header_buf_used) && (header_buf[i]=='\r' || header_buf[i] == '\n'))
 						i++;
 					linestart = i;
 					colon = linestart;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in getHTTPResponse that was cloned from https://github.com/miniupnp/miniupnp but did not receive the security patch.

###Details:
Affected Function: getHTTPResponse in External/RakNet/DependentExtensions/miniupnpc-1.6.20120410/miniwget.c
Original Fix: https://github.com/miniupnp/miniupnp/commit/3a87aa2f10bd7f1408e1849bdb59c41dd63a9fe9

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/miniupnp/miniupnp/commit/3a87aa2f10bd7f1408e1849bdb59c41dd63a9fe9
- https://nvd.nist.gov/vuln/detail/CVE-2014-3985

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
