### PR TITLE
[SkipIntro] Fix crash if SCENE_FILE was not set to the boot scene

### DIFF
--- a/Mods/SkipIntro/Src/SkipIntro.cpp
+++ b/Mods/SkipIntro/Src/SkipIntro.cpp
@@ -15,9 +15,9 @@ DEFINE_PLUGIN_DETOUR(SkipIntro, ZString*, ZEngineAppCommon_GetBootScene, ZEngine
         return HookResult<ZString*>(HookAction::Continue());
     }
 
-    const ZString& s_ScenePath = (*Globals::ComponentManager)->m_pApplication->GetOption("SCENE_FILE");
+    result = (*Globals::ComponentManager)->m_pApplication->GetOption("SCENE_FILE");
 
-    if (s_ScenePath == "assembly:/_PRO/Scenes/Frontend/Boot.entity") {
+    if (result == "assembly:/_PRO/Scenes/Frontend/Boot.entity") {
         result = "assembly:/_PRO/Scenes/Frontend/MainMenu.entity";
     }
 


### PR DESCRIPTION
As title.