### PR TITLE
Fix tables in AdvancedRating and FreeCam mods

### DIFF
--- a/Mods/AdvancedRating/Src/AdvancedRating.cpp
+++ b/Mods/AdvancedRating/Src/AdvancedRating.cpp
@@ -49,23 +49,23 @@ void AdvancedRating::OnDrawUI(bool p_HasFocus) {
     ImGui::PushFont(SDK()->GetImGuiRegularFont());
 
     if (s_WindowExpanded) {
-        ImGui::BeginTable("RatingTable", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_ScrollY);
+        if (ImGui::BeginTable("RatingTable", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_ScrollY)){
+            AcquireSRWLockShared(&m_EventLock);
 
-        AcquireSRWLockShared(&m_EventLock);
+            for (auto& s_Event : m_EventHistory) {
+                auto s_TypeName = s_Event.TypeToString();
 
-        for (auto& s_Event : m_EventHistory) {
-            auto s_TypeName = s_Event.TypeToString();
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::TextUnformatted(s_TypeName.c_str(), s_TypeName.c_str() + s_TypeName.size());
+                ImGui::TableNextColumn();
+                ImGui::Text("%lld", s_Event.Points);
+            }
 
-            ImGui::TableNextRow();
-            ImGui::TableNextColumn();
-            ImGui::TextUnformatted(s_TypeName.c_str(), s_TypeName.c_str() + s_TypeName.size());
-            ImGui::TableNextColumn();
-            ImGui::Text("%lld", s_Event.Points);
+            ReleaseSRWLockShared(&m_EventLock);
+
+            ImGui::EndTable();
         }
-
-        ReleaseSRWLockShared(&m_EventLock);
-
-        ImGui::EndTable();
     }
 
     ImGui::PopFont();

--- a/Mods/FreeCam/Src/FreeCam.cpp
+++ b/Mods/FreeCam/Src/FreeCam.cpp
@@ -382,45 +382,43 @@ void FreeCam::OnDrawUI(bool p_HasFocus) {
         if (s_ControlsExpanded) {
             ImGui::TextUnformatted("PC Controls");
 
-            ImGui::BeginTable("FreeCamControlsPc", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_SizingFixedFit);
-
-            if (m_EditorStyleFreecam) {
-                for (auto& [s_Key, s_Description] : m_PcControlsEditorStyle) {
-                    ImGui::TableNextRow();
-                    ImGui::TableNextColumn();
-                    ImGui::TextUnformatted(s_Key.c_str());
-                    ImGui::TableNextColumn();
-                    ImGui::TextUnformatted(s_Description.c_str());
+            if (ImGui::BeginTable("FreeCamControlsPc", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_SizingFixedFit)){
+                if (m_EditorStyleFreecam) {
+                    for (auto& [s_Key, s_Description] : m_PcControlsEditorStyle) {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn();
+                        ImGui::TextUnformatted(s_Key.c_str());
+                        ImGui::TableNextColumn();
+                        ImGui::TextUnformatted(s_Description.c_str());
+                    }
                 }
-            }
-            else {
-                for (auto& [s_Key, s_Description] : m_PcControls) {
-                    ImGui::TableNextRow();
-                    ImGui::TableNextColumn();
-                    ImGui::TextUnformatted(s_Key.c_str());
-                    ImGui::TableNextColumn();
-                    ImGui::TextUnformatted(s_Description.c_str());
+                else {
+                    for (auto& [s_Key, s_Description] : m_PcControls) {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn();
+                        ImGui::TextUnformatted(s_Key.c_str());
+                        ImGui::TableNextColumn();
+                        ImGui::TextUnformatted(s_Description.c_str());
+                    }
                 }
-            }
 
-            ImGui::EndTable();
+                ImGui::EndTable();
+            }
 
             if (!m_EditorStyleFreecam) {
                 ImGui::TextUnformatted("Controller Controls");
 
-                ImGui::BeginTable(
-                    "FreeCamControlsController", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_SizingFixedFit
-                );
+                if (ImGui::BeginTable("FreeCamControlsController", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_SizingFixedFit)){
+                    for (auto& [s_Key, s_Description] : m_ControllerControls) {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn();
+                        ImGui::TextUnformatted(s_Key.c_str());
+                        ImGui::TableNextColumn();
+                        ImGui::TextUnformatted(s_Description.c_str());
+                    }
 
-                for (auto& [s_Key, s_Description] : m_ControllerControls) {
-                    ImGui::TableNextRow();
-                    ImGui::TableNextColumn();
-                    ImGui::TextUnformatted(s_Key.c_str());
-                    ImGui::TableNextColumn();
-                    ImGui::TextUnformatted(s_Description.c_str());
+                    ImGui::EndTable();
                 }
-
-                ImGui::EndTable();
             }
         }
 


### PR DESCRIPTION
This PR changes code related to Dear ImGui tables so `EndTable()` is only called within `BeginTable()` scope.

This fixes errors like this:

<img width="1304" height="146" alt="advancedrating_imgui_issue" src="https://github.com/user-attachments/assets/3b47e69f-ef57-4b4d-8189-c0d1836b567d" />

(GitHub diff is doing some crazy things, i guess just open this in a proper IDE and it should look fine)