### PR TITLE
[NavKit] Add onlyCollidable option to scene extraction

### DIFF
--- a/Mods/Editor/Src/Components/EditorAPI.cpp
+++ b/Mods/Editor/Src/Components/EditorAPI.cpp
@@ -302,11 +302,12 @@ void Editor::FindAlocAndPrimForZGeomEntityNode(
     const char*& p_EntityType,
     const std::unordered_map<std::string, std::string>& p_RoomNameToFolderName,
     std::map<std::string, NavKitMatiTextures>& p_MatiTextures,
-    std::map<std::string, std::vector<std::string>>& p_PrimMatis
+    std::map<std::string, std::vector<std::string>>& p_PrimMatis,
+    bool s_OnlyCollidableMeshes
 ) {
     std::string s_AlocHash = GetCollisionHash(p_Node->Entity);
 
-    if (s_AlocHash.empty() || s_AlocHash == "null") {
+    if (s_OnlyCollidableMeshes && (s_AlocHash.empty() || s_AlocHash == "null")) {
         return;
     }
 
@@ -459,7 +460,8 @@ void Editor::FindAlocAndPrimForZPrimitiveProxyEntityNode(
     const char*& s_EntityType,
     const std::unordered_map<std::string, std::string>& roomNameToFolderName,
     std::map<std::string, NavKitMatiTextures>& p_MatiTextures,
-    std::map<std::string, std::vector<std::string>>& p_PrimMatis
+    std::map<std::string, std::vector<std::string>>& p_PrimMatis,
+    bool s_OnlyCollidableMeshes
 ) {
     std::string s_Id = std::format("{:016x}", s_Node->Entity->GetType()->m_nEntityID);
     std::string s_PrimHash =
@@ -467,7 +469,7 @@ void Editor::FindAlocAndPrimForZPrimitiveProxyEntityNode(
     // TODO: Check if the prim hash is needed here
 
     if (std::string s_AlocHash = GetCollisionHash(s_Node->Entity);
-        !s_AlocHash.empty() && s_AlocHash != "null") {
+        !s_OnlyCollidableMeshes || (!s_AlocHash.empty() && s_AlocHash != "null")) {
         bool s_Skip = false;
 
         for (auto s_Interface : s_Interfaces) {
@@ -518,6 +520,7 @@ void Editor::FindAlocAndPrimForZPrimitiveProxyEntityNode(
 }
 
 void Editor::FindMeshes(
+    const bool s_OnlyCollidableMeshes,
     const std::function<void(
         std::vector<NavKitMeshEntity>&,
         std::map<std::string, NavKitMatiTextures>&,
@@ -595,10 +598,10 @@ void Editor::FindMeshes(
             }
 
             if (const char* s_EntityType = s_TypeInfo->pszTypeName; strcmp(s_EntityType, "ZGeomEntity") == 0) {
-                FindAlocAndPrimForZGeomEntityNode(s_Entities, s_Node, s_Interfaces, s_EntityType, s_RoomNameToFolderName, s_MatiTextures, s_PrimMatis);
+                FindAlocAndPrimForZGeomEntityNode(s_Entities, s_Node, s_Interfaces, s_EntityType, s_RoomNameToFolderName, s_MatiTextures, s_PrimMatis, s_OnlyCollidableMeshes);
             }
             else if (strcmp(s_EntityType, "ZPrimitiveProxyEntity") == 0) {
-                FindAlocAndPrimForZPrimitiveProxyEntityNode(s_Entities, s_Node, s_Interfaces, s_EntityType, s_RoomNameToFolderName, s_MatiTextures, s_PrimMatis);
+                FindAlocAndPrimForZPrimitiveProxyEntityNode(s_Entities, s_Node, s_Interfaces, s_EntityType, s_RoomNameToFolderName, s_MatiTextures, s_PrimMatis, s_OnlyCollidableMeshes);
             }
 
             // Add children to the queue.

--- a/Mods/Editor/Src/Editor.h
+++ b/Mods/Editor/Src/Editor.h
@@ -65,11 +65,10 @@ public:
     ZEntityRef FindEntity(EntitySelector p_Selector);
     static std::string GetCollisionHash(auto p_SelectedEntity);
     void FindMeshes(
-        const std::function<void(
-            std::vector<NavKitMeshEntity>&, std::map<std::string, NavKitMatiTextures>&,
-            std::map<std::string, std::vector<std::string>>&, bool
-            )>&
-        p_SendEntitiesCallback, const std::function<void()>& p_RebuiltCallback
+        bool s_OnlyCollidableMeshes, const std::function<void(std::vector<NavKitMeshEntity>&, std::map<std::string,
+            NavKitMatiTextures>&, std
+            ::map<std::string, std::vector<std::string>>&, bool)>& p_SendEntitiesCallback, const std::function<void()>&
+        p_RebuiltCallback
     );
     std::vector<std::tuple<std::vector<std::string>, Quat, ZEntityRef>> FindEntitiesByType(
         const std::string& p_EntityType, const std::string& p_Hash
@@ -221,14 +220,15 @@ private:
         const std::shared_ptr<EntityTreeNode>& p_Node, const TArray<SInterfaceData>& p_Interfaces, const char*& p_EntityType, const
         std::unordered_map<std::string, std::string>& p_RoomNameToFolderName,
         std::map<std::string, NavKitMatiTextures>& p_MatiTextures,
-        std::map<std::string, std::vector<std::string>>& p_PrimMatis
+        std::map<std::string, std::vector<std::string>>& p_PrimMatis, bool s_OnlyCollidableMeshes
     );
     static void FindAlocAndPrimForZPrimitiveProxyEntityNode(
         std::vector<NavKitMeshEntity>& s_Entities,
         const std::shared_ptr<EntityTreeNode>& s_Node, const TArray<SInterfaceData>& s_Interfaces, const char*& s_EntityType, const
-        std::unordered_map<std::string, std::string>& roomNameToFolderName,
+        std::unordered_map<std::string, std::string>&
+        roomNameToFolderName,
         std::map<std::string, NavKitMatiTextures>& p_MatiTextures,
-        std::map<std::string, std::vector<std::string>>& p_PrimMatis
+        std::map<std::string, std::vector<std::string>>& p_PrimMatis, bool s_OnlyCollidableMeshes
     );
 
     // Properties

--- a/Mods/Editor/Src/EditorServer.cpp
+++ b/Mods/Editor/Src/EditorServer.cpp
@@ -209,9 +209,16 @@ void EditorServer::OnMessage(WebSocket* p_Socket, std::string_view p_Message, uW
         SendEntityList(p_Socket, Plugin()->GetEntityTree(), s_MessageId);
     }
     else if (s_Type == "listAlocPfBoxAndSeedPointEntities") {
+
+        bool s_OnlyCollidableMeshes = true;
+        if (auto result = s_JsonMsg["onlyCollidable"]; result.error() == simdjson::SUCCESS) {
+            if (result.type() == simdjson::ondemand::json_type::boolean) {
+                s_OnlyCollidableMeshes = result.get_bool();
+            }
+        }
         Plugin()->QueueTask(
-            [p_Socket, p_Loop]() {
-                SendNavKitScene(p_Socket, p_Loop);
+            [p_Socket, p_Loop, s_OnlyCollidableMeshes]() {
+                SendNavKitScene(p_Socket, p_Loop, s_OnlyCollidableMeshes);
             }
         );
     }
@@ -671,7 +678,7 @@ bool EditorServer::GetEnabled() {
     return m_Enabled;
 }
 
-void EditorServer::SendNavKitScene(WebSocket* p_Socket, uWS::Loop* p_Loop) {
+void EditorServer::SendNavKitScene(WebSocket* p_Socket, uWS::Loop* p_Loop, bool s_OnlyCollidableMeshes) {
     p_Loop->defer(
         [p_Socket]() {
             p_Socket->send(R"({"version":1,"meshes":[)", uWS::OpCode::TEXT);
@@ -685,6 +692,7 @@ void EditorServer::SendNavKitScene(WebSocket* p_Socket, uWS::Loop* p_Loop) {
     Logger::Info("[Editor] Sending Meshes...");
 
     Plugin()->FindMeshes(
+        s_OnlyCollidableMeshes,
         [p_Socket, p_Loop, s_AnyMeshSentOverall, s_TotalMeshesSent, s_LastLoggedMilestone](
             const std::vector<NavKitMeshEntity>& p_Entities,
             const std::map<std::string, NavKitMatiTextures>& p_MatiTextures,

--- a/Mods/Editor/Src/EditorServer.h
+++ b/Mods/Editor/Src/EditorServer.h
@@ -54,7 +54,7 @@ private:
         WebSocket* p_Socket, std::shared_ptr<EntityTreeNode> p_Tree, std::optional<int64_t> p_MessageId
     );
     static void SendEntityDetails(WebSocket* p_Socket, ZEntityRef p_Entity, std::optional<int64_t> p_MessageId);
-    static void SendNavKitScene(WebSocket* p_Socket, uWS::Loop* p_Loop);
+    static void SendNavKitScene(WebSocket* p_Socket, uWS::Loop* p_Loop, bool s_OnlyCollidableMeshes);
     static bool SendEntitiesDetails(
         WebSocket* p_Socket, const std::vector<std::tuple<std::vector<std::string>, Quat, ZEntityRef>>& p_Entities
     );


### PR DESCRIPTION
## Description
This PR adds an option to the NavKit scene extraction message called `onlyCollidable` that defaults to `true`.
When it is true, prims that do not have alocs are skipped.
When it is false, prims that do not have alocs are not skipped.

### Screenshot
<img width="2555" height="1385" alt="image" src="https://github.com/user-attachments/assets/0084522b-088f-4c4d-9c41-777359eac107" />
